### PR TITLE
Enable wowinterface classic addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The following hosts are supported as download targets. The URL specified should 
 |---------------|--------|---------|
 | Curse         | ✅      | ✅       |
 | WoWAce        | ✅      | ❌ Soon  |
-| WoWInterface  | ✅      | ❌ Soon  |
+| WoWInterface  | ✅      | ✅       |
 | GitHub        | ✅      | ✅       |
 | Tukui         | ✅      | ✅       |
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 Changelog
 
+* 9/3/2019
+Add support for WoWInterface classic addons.
+
 * 8/31/2019
 Add command-line argument for specifying a configuration file. Now multiple independent configurations can be used i.e. one for retail, and one for classic.
 

--- a/updater/site/wowinterface.py
+++ b/updater/site/wowinterface.py
@@ -10,8 +10,6 @@ class WoWInterface(AbstractSite):
     _URL = 'https://www.wowinterface.com/downloads/'
 
     def __init__(self, url: str, game_version: GameVersion):
-        if game_version is GameVersion.classic:
-            raise NotImplementedError("Updating classic addons are not yet supported for WoWInterface.")
         super().__init__(url, game_version)
 
     @classmethod


### PR DESCRIPTION
WoWInterface for #50 

Came for free, since addons on WoWInterface are for only one client version at a time. The URLs are unique for classic.