### PR TITLE
Cloudflare bot buster

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,5 +9,6 @@ coverage = "*"
 [packages]
 requests = "*"
 beautifulsoup4 = "*"
+cfscrape = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a0640d3ee8ca7c9c299fd465369012d970dad6f705a66e820a350bef3f983816"
+            "sha256": "cd1ddff1b0f508f44fe46826948604b63363f22a3d304ee2c606f385ec154e9b"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -25,10 +25,19 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
+        },
+        "cfscrape": {
+            "hashes": [
+                "sha256:45fb82043f824717345b03bfabd80b19b615eaf3d8228cf1d5c3c50e2c6eb259",
+                "sha256:55913cb9ff2f39ad796fad2ba8888f12707daba4d8a28f3e34957804a4d8ecb8",
+                "sha256:7c52c19b74a10dd29223f03926581754d0f0bf7f94caaeca163e4bb911ca1c4b"
+            ],
+            "index": "pypi",
+            "version": "==2.0.8"
         },
         "chardet": {
             "hashes": [
@@ -54,17 +63,17 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:8662843366b8d8779dec4e2f921bebec9afd856a5ff2e82cd419acc5054a1a92",
-                "sha256:a5a6166b4767725fd52ae55fee8c8b6137d9a51e9f1edea461a062a759160118"
+                "sha256:605f89ad5fdbfefe30cdc293303665eff2d188865d4dbe4eb510bba1edfbfce3",
+                "sha256:b91d676b330a0ebd5b21719cb6e9b57c57d433671f65b9c28dd3461d9a1ed0b6"
             ],
-            "version": "==1.9.3"
+            "version": "==1.9.4"
         },
         "urllib3": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398",
+                "sha256:9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
             ],
-            "version": "==1.25.3"
+            "version": "==1.25.6"
         }
     },
     "develop": {

--- a/README.md
+++ b/README.md
@@ -8,20 +8,22 @@ _Now supporting both retail and classic addon management!_
 
 ## First-time setup
 
-You must have a version of [Python](https://www.python.org/) 3.6+.
+### System dependencies
+- You must have a version of [Python](https://www.python.org/) 3.6+.
 
-_If you know how to manage Python packages and virtual environments, you can skip this section._
+- You must have [Node.js](https://nodejs.org/en/) installed (for Curse and WoWAce addons only).
+    - Used by `cfscrape` to circumvent the Cloudflare _"bot-detection"_ found on CurseForge sites.
+
+### Python module dependencies
 
 You should already have `pip` included with your Python installation. This is the default package manager for Python.
 If not, download the latest version of Python  for your platform, with `pip` bundled.
 
-
-### Installing the dependencies
-
-This utility has two external dependencies:
+This utility has three Python module dependencies:
 
 - The [requests](https://pypi.org/project/requests/) module, for making HTTP requests
 - The [BeautifulSoup4](https://pypi.org/project/beautifulsoup4/) module, for HTML document parsing
+- The [cfscrape](https://pypi.org/project/cfscrape/) module, for bypassing Curse's bot-detection measures
 
 It's recommended you manage this with [`pipenv`](https://github.com/pypa/pipenv). All you need to do is run the following to install `pipenv` and the dependencies:
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 Changelog
 
+* 9/28/2019
+Integrated cfscrape as an anti-measure for Cloudflare bot-detection, for Curse and WoWAce. Node.js is now a requirement for Curse-based sites.
+
 * 9/24/2019
 Fix WoWInterface site to accept any characters for the addon name instead of a more rigid regex.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,18 +1,18 @@
 Changelog
 
-* 9/28/2019
+* 9/28/2019 - v1.2.0
 Integrated cfscrape as an anti-measure for Cloudflare bot-detection, for Curse and WoWAce. Node.js is now a requirement for Curse-based sites.
 
-* 9/24/2019
+* 9/24/2019 - v1.1.2
 Fix WoWInterface site to accept any characters for the addon name instead of a more rigid regex.
 
-* 9/23/2019
+* 9/23/2019 - v1.1.1
 Add message for when Curse is being a jerk and blocking your requests.
 
-* 9/3/2019
+* 9/3/2019 - v1.1.0
 Add support for WoWInterface classic addons.
 
-* 8/31/2019
+* 8/31/2019 - v1.0
 Add command-line argument for specifying a configuration file. Now multiple independent configurations can be used i.e. one for retail, and one for classic.
 
 * 8/31/2019

--- a/test/site/test_curse.py
+++ b/test/site/test_curse.py
@@ -12,7 +12,6 @@ version_test_data = [
 ]
 
 
-@unittest.skip
 class TestCurse(unittest.TestCase):
     def setUp(self):
         self.url = 'https://www.curseforge.com/wow/addons/bartender4'

--- a/test/site/test_wowace.py
+++ b/test/site/test_wowace.py
@@ -4,7 +4,6 @@ from updater.site import wowace
 from updater.site.enum import GameVersion
 
 
-@unittest.skip
 class TestWowAce(unittest.TestCase):
     def setUp(self):
         self.url = 'https://www.wowace.com/projects/bartender4'

--- a/updater/__main__.py
+++ b/updater/__main__.py
@@ -7,7 +7,13 @@ from updater.manager.addon_manager import AddonManager
 
 CHANGELOG_URL = 'https://raw.githubusercontent.com/grrttedwards/wow-addon-updater/master/changelog.txt'
 CHANGELOG_FILE = 'changelog.txt'
-NEW_UPDATE_MESSAGE = 'A new update is available! Check it out at https://github.com/grrttedwards/wow-addon-updater !'
+NEW_UPDATE_MESSAGE = """
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A new update is available! Check it out at https://github.com/grrttedwards/wow-addon-updater/releases
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"""
 
 
 def confirm_exit():
@@ -25,15 +31,14 @@ def check_version():
 
 
 def main():
-    check_version()
-
     parser = argparse.ArgumentParser(description='Update your WoW addons.')
     parser.add_argument('-c', '--config', nargs='?', default='config.ini', type=str, metavar='FILE',
                         help='the file to be used for configuration')
-
     args = parser.parse_args()
 
     AddonManager(args.config).update_all()
+
+    check_version()
 
 
 if __name__ == "__main__":

--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -94,7 +94,7 @@ class AddonManager:
 
             try:
                 zip_url = site.find_zip_url()
-                addon_zip = self.get_addon_zip(zip_url)
+                addon_zip = self.get_addon_zip(site.session, zip_url)
                 self.extract_to_addons(addon_zip, subfolder, site)
             except HTTPError:
                 print(f"Failed to download zip for [{addon_name}]")
@@ -112,8 +112,8 @@ class AddonManager:
         addon_entry = [addon_name, addon_url, installed_version, latest_version]
         self.manifest.append(addon_entry)
 
-    def get_addon_zip(self, zip_url):
-        r = requests.get(zip_url, stream=True)
+    def get_addon_zip(self, session: requests.Session, zip_url):
+        r = session.get(zip_url, stream=True)
         r.raise_for_status()  # Raise an exception for HTTP errors
         return zipfile.ZipFile(BytesIO(r.content))
 

--- a/updater/site/abstract_site.py
+++ b/updater/site/abstract_site.py
@@ -8,6 +8,9 @@ class SiteError(Exception):
 
 
 class AbstractSite(ABC):
+    # each implementation should create a static session for itself
+    session = None
+
     def __init__(self, url: str, game_version: GameVersion):
         self.url = url
         self.game_version = game_version

--- a/updater/site/github.py
+++ b/updater/site/github.py
@@ -9,6 +9,8 @@ from updater.site.enum import GameVersion
 class GitHub(AbstractSite):
     _URL = 'https://github.com/'
 
+    session = requests.session()
+
     def __init__(self, url: str):
         if '/tree/master' not in url:
             url = (url + '/tree/master')
@@ -23,7 +25,7 @@ class GitHub(AbstractSite):
 
     def get_latest_version(self):
         try:
-            response = requests.get(self.url)
+            response = GitHub.session.get(self.url)
             response.raise_for_status()
             content = str(response.content)
             version = re.search(

--- a/updater/site/tukui.py
+++ b/updater/site/tukui.py
@@ -9,6 +9,8 @@ class Tukui(AbstractSite):
     _URL = 'https://git.tukui.org/elvui/'
     latest_version = None
 
+    session = requests.session()
+
     def __init__(self, url: str):
         super().__init__(url, GameVersion.agnostic)
 
@@ -25,7 +27,7 @@ class Tukui(AbstractSite):
         if self.latest_version:
             return self.latest_version
         try:
-            response = requests.get(self.url + '/-/tags')
+            response = Tukui.session.get(self.url + '/-/tags')
             response.raise_for_status()
             tags_page = BeautifulSoup(response.text, 'html.parser')
             version = tags_page.find('div', {'class': 'tags'}).find('a').string

--- a/updater/site/wowace.py
+++ b/updater/site/wowace.py
@@ -1,6 +1,6 @@
 import re
 
-import requests
+import cfscrape
 
 from updater.site.abstract_site import AbstractSite
 from updater.site.enum import GameVersion
@@ -8,6 +8,8 @@ from updater.site.enum import GameVersion
 
 class WoWAce(AbstractSite):
     _URL = 'https://www.wowace.com/projects/'
+
+    session = cfscrape.create_scraper()
 
     def __init__(self, url: str, game_version: GameVersion):
         if game_version != GameVersion.retail:
@@ -23,10 +25,9 @@ class WoWAce(AbstractSite):
 
     def get_latest_version(self):
         try:
-            page = requests.get(self.url + '/files')
+            page = WoWAce.session.get(self.url + '/files')
             if page.status_code in [403, 503]:
-                print("WoWAce (Curse) is temporarily blocking requests because it thinks you are a bot... please try later. "
-                      "Consider finding this addon on WoWInterface or GitHub.")
+                print("WoWAce (Curse) is blocking requests because it thinks you are a bot... please try later.")
             page.raise_for_status()  # Raise an exception for HTTP errors
             content_string = str(page.content)
             # the first one encountered will be the WoW retail version

--- a/updater/site/wowinterface.py
+++ b/updater/site/wowinterface.py
@@ -9,6 +9,8 @@ from updater.site.enum import GameVersion
 class WoWInterface(AbstractSite):
     _URL = 'https://www.wowinterface.com/downloads/'
 
+    session = requests.session()
+
     def __init__(self, url: str, game_version: GameVersion):
         super().__init__(url, game_version)
 
@@ -19,7 +21,7 @@ class WoWInterface(AbstractSite):
     def find_zip_url(self):
         downloadpage = self.url.replace('info', 'download')
         try:
-            page = requests.get(downloadpage + '/download')
+            page = WoWInterface.session.get(downloadpage + '/download')
             page.raise_for_status()  # Raise an exception for HTTP errors
             content_string = str(page.content)
             index_of_ziploc = content_string.find('Problems with the download? <a href="') + 37  # first char of the url
@@ -30,7 +32,7 @@ class WoWInterface(AbstractSite):
 
     def get_latest_version(self):
         try:
-            page = requests.get(self.url)
+            page = WoWInterface.session.get(self.url)
             page.raise_for_status()  # Raise an exception for HTTP errors
             content_string = str(page.content)
             index_of_ver = content_string.find('id="version"') + 22  # first char of the version string


### PR DESCRIPTION
#68 #69 #72

Bring in the Nodejs-powered package [`cfscrape`](https://github.com/Anorov/cloudflare-scrape) for bypassing the Cloudflare bot protection page on Curse and WoWAce (owned by Curse) pages.

This also brings in a slight refactor to maintain sessions for all Site types. Shouldn't really matter, but this is slightly cleaner anyways.

## **THIS WILL REQUIRE THE NODE.JS EXECUTABLE ON YOUR MACHINE**

I'm not particularly fond of this, but once Node is installed, then `cfscrape` can do its job.