### PR TITLE
Don't remove existing addon installations if an extraction fails

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 Changelog
 
+* 10/5/2019 - v1.2.2
+Fix for a problem where an existing installed addon can be deleted, and the new extract fails, which essentially deletes the addon from the system.
+
 * 9/29/2019 - v1.2.1
 Relaxed the pattern match for most URLs which may not be prefixed with "www.".
 

--- a/test/manager/test_addon_manager.py
+++ b/test/manager/test_addon_manager.py
@@ -78,6 +78,14 @@ class TestAddonManager(unittest.TestCase):
         self.manager.update_addon(TEST_URL)
         self.assertFailedInstall()
 
+    """ 
+    Issue #80 https://github.com/grrttedwards/wow-addon-updater/issues/80
+    """
+    def test_subfolder_extraction_fail_doesnt_install_addon(self):
+        self.manager.extract_to_addons = Mock(side_effect=KeyError())
+        self.manager.update_addon(TEST_URL)
+        self.assertFailedInstall()
+
     def test_extract_archive_subfolder(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             self.extractAddon('some-fake-addon.zip', temp_dir, curse.Curse("", GameVersion.retail),
@@ -105,6 +113,18 @@ class TestAddonManager(unittest.TestCase):
             self.assertExtractionSuccess(temp_dir, 'FolderA', 'sub-folder', 'file1.txt')
             self.assertExtractionSuccess(temp_dir, 'FolderB', 'fileB.txt')
             self.assertExtractionSuccess(temp_dir, 'FolderC', 'fileC.txt')
+
+    """ 
+    Issue #80 https://github.com/grrttedwards/wow-addon-updater/issues/80
+    """
+    def test_zip_subfolder_extract_fail_raises_error(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            def extract_should_fail():
+                return self.extractAddon('some-fake-addon.zip', temp_dir, None, subfolder='existing-addon')
+            existing_addon_dir = os.path.join(temp_dir, 'existing-addon')
+            os.mkdir(existing_addon_dir)
+            self.assertRaises(KeyError, extract_should_fail)
+            self.assertTrue(os.path.isdir(existing_addon_dir))
 
 
 if __name__ == '__main__':

--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -100,7 +100,7 @@ class AddonManager:
                 print(f"Failed to download zip for [{addon_name}]")
                 latest_version = AddonManager._UNAVAILABLE
             except KeyError:
-                print(f"Failed to find subfolder [{subfolder}] in archive for [{addon_name}]")
+                print(f"Failed to extract subfolder [{subfolder}] in archive for [{addon_name}]")
                 latest_version = AddonManager._UNAVAILABLE
             except SiteError as e:
                 print(e)
@@ -131,6 +131,8 @@ class AddonManager:
                     destination_dir = join(self.wow_addon_location, subfolder)
                     temp_source_dir = join(temp_dir, top_level_folder, subfolder)
                 zipped.extractall(path=temp_dir)
+                if not isdir(temp_source_dir):
+                    raise KeyError()
                 if isdir(destination_dir):
                     shutil.rmtree(destination_dir)
                 shutil.copytree(src=temp_source_dir, dst=destination_dir)


### PR DESCRIPTION
#80 
User found a problem with extraction code greedily removing the existing addon install folder without making sure it can really put the new version in place.

This is one step to make sure that doesn't happen, but there is additional work somewhere to make subfolders work for all the sites. i.e. Curse and Github and Tukui all need special code, since the archives are all different structures.