### PR TITLE
Add wslpath normalization for a Windows path in the Linux subsystem

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 Changelog
 
+* 10/5/2019 - v1.3.0
+Add the ability to use a Windows-style addon directory path when using Windows, but calling the code from within Windows Subsystem for Linux.
+
 * 10/5/2019 - v1.2.2
 Fix for a problem where an existing installed addon can be deleted, and the new extract fails, which essentially deletes the addon from the system.
 

--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -1,5 +1,7 @@
 import configparser
+import platform
 import shutil
+import subprocess
 import tempfile
 import threading
 import zipfile
@@ -17,6 +19,13 @@ from updater.site.enum import GameVersion
 def error(message: str):
     print(message)
     exit(1)
+
+
+def normalize_path(path: str) -> str:
+    env = platform.platform().lower()
+    if 'linux' in env and 'microsoft' in env:
+        return subprocess.check_output(['wslpath', path], text=True)
+    return path
 
 
 class AddonManager:
@@ -43,6 +52,7 @@ class AddonManager:
         if not isfile(self.addon_list_file):
             error(f"Failed to read addon list file ({self.addon_list_file}). Are you sure the file exists?")
 
+        self.wow_addon_location = normalize_path(self.wow_addon_location)
         if not isdir(self.wow_addon_location):
             error(f"Could not find addon directory ({self.wow_addon_location}). Are you sure it exists?")
 


### PR DESCRIPTION
#26 - Thanks to the original poster @fspy , but that code is from a deleted branch and I can't work on it.

This should enable WSL users to use the tool and define a Windows-style path, but call it from Linux.