### PR TITLE
Add classic support for WowAce

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following hosts are supported as download targets. The URL specified should 
 |               | Retail | Classic |
 |---------------|--------|---------|
 | Curse         | ✅      | ✅       |
-| WoWAce        | ✅      | ❌ Soon  |
+| WoWAce        | ✅      | ✅       |
 | WoWInterface  | ✅      | ✅       |
 | GitHub        | ✅      | ✅       |
 | Tukui         | ✅      | ✅       |

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 Changelog
 
+* 10/6/2019 - v1.4.0
+Add support for WowAce classic addons.
+
 * 10/5/2019 - v1.3.0
 Add the ability to use a Windows-style addon directory path when using Windows, but calling the code from within Windows Subsystem for Linux.
 

--- a/test/site/test_curse.py
+++ b/test/site/test_curse.py
@@ -33,8 +33,6 @@ class TestCurse(unittest.TestCase):
         for url, version_regex in version_test_data:
             for game_version in GameVersion.__members__.values():
                 with self.subTest((game_version, url, version_regex)):
-                    if 'weakauras' in url and game_version is GameVersion.classic:
-                        return  # weakauras doesn't have a classic download link yet
                     c = curse.Curse(url, game_version)
                     latest_version = c.get_latest_version()
                     # something like 4.5.6, or v163

--- a/test/site/test_wowace.py
+++ b/test/site/test_wowace.py
@@ -3,6 +3,13 @@ import unittest
 from updater.site import wowace
 from updater.site.enum import GameVersion
 
+version_test_data = [
+    ['https://www.wowace.com/projects/prat-3-0', r'[0-9]+\.[0-9]+\.[0-9]+'],
+    ['https://www.wowace.com/projects/bartender4', r'[0-9]+\.[0-9]+\.[0-9]+'],
+    ['https://www.wowace.com/projects/shadowed-unit-frames', r'v[0-9]+'],
+    ['https://www.wowace.com/projects/acp', r'[0-9]+\.[0-9]+\.[0-9]+'],
+    ['https://www.wowace.com/projects/weakauras-2', r'[0-9]+\.[0-9]+\.[0-9]+']
+]
 
 class TestWowAce(unittest.TestCase):
     def setUp(self):
@@ -10,18 +17,25 @@ class TestWowAce(unittest.TestCase):
         self.wowace = wowace.WoWAce(self.url, GameVersion.retail)
 
     def test_integration_wowace_find_zip_url(self):
-        zip_url = self.wowace.find_zip_url()
-        # example: https://www.wowace.com/projects/bartender4/files/latest
-        self.assertEqual(zip_url, f"{self.url}/files/latest")
+        for game_version in GameVersion.__members__.values():
+            with self.subTest(game_version):
+                c = wowace.WoWAce(self.url, game_version)
+                zip_url = c.find_zip_url()
+                # example for bartender 4.8.8 release: https://www.wowace.com/projects/bartender4/files/2794704/download
+                self.assertRegex(zip_url.lower(), rf'{self.url}/files/[0-9]+/download')
 
     def test_integration_wowace_get_addon_name(self):
         addon_name = self.wowace.get_addon_name()
         self.assertEqual(addon_name, 'bartender4')
 
     def test_integration_wowace_get_latest_version(self):
-        latest_version = self.wowace.get_latest_version()
-        # something like 4.5.6-1-g1234567
-        self.assertRegex(latest_version, r"[0-9]+\.[0-9]+\.[0-9]+")
+        for url, version_regex in version_test_data:
+            for game_version in GameVersion.__members__.values():
+                with self.subTest((game_version, url, version_regex)):
+                    c = wowace.WoWAce(url, game_version)
+                    latest_version = c.get_latest_version()
+                    # something like 4.5.6, or v163
+                    self.assertRegex(latest_version, version_regex)
 
     def test_wowace_get_supported_urls(self):
         supported_urls = self.wowace.get_supported_urls()

--- a/updater/site/wowace.py
+++ b/updater/site/wowace.py
@@ -1,6 +1,5 @@
-import re
-
 import cfscrape
+from bs4 import BeautifulSoup
 
 from updater.site.abstract_site import AbstractSite
 from updater.site.enum import GameVersion
@@ -13,26 +12,42 @@ class WoWAce(AbstractSite):
     ]
 
     session = cfscrape.create_scraper()
+    latest_version = None
+    page = None
 
     def __init__(self, url: str, game_version: GameVersion):
-        if game_version != GameVersion.retail:
-            raise NotImplementedError("Updating classic addons are not yet supported for WoWAce.")
         super().__init__(url, game_version)
 
     def find_zip_url(self):
-        return self.url + '/files/latest'
+        return f"https://www.wowace.com{self._get_page().find('a', text=self.get_latest_version()).get('href')}/download"
 
     def get_latest_version(self):
+        if self.latest_version:
+            return self.latest_version
+        
         try:
-            page = WoWAce.session.get(self.url + '/files')
-            if page.status_code in [403, 503]:
-                print("WoWAce (Curse) is blocking requests because it thinks you are a bot... please try later.")
-            page.raise_for_status()  # Raise an exception for HTTP errors
-            content_string = str(page.content)
-            # the first one encountered will be the WoW retail version
-            version = re.search(
-                r"project-file-name-container.+?data-id=.+?data-name=\"(?P<version>.+?)\"",
-                content_string).group('version')
+            page = self._get_page()
+            recent_wrappers = page.find_all('ul', {'class': 'cf-recentfiles'}) 
+
+            if (len(recent_wrappers) == 1) or (self.game_version == GameVersion.retail):
+                version = recent_wrappers[0].find('a', {'data-action': 'file-link'}).text
+            else:
+                version = recent_wrappers[1].find('a', {'data-action': 'file-link'}).text
+
+            self.latest_version = version
             return version
+        except Exception as e:
+            raise self.version_error() from e
+    
+    def _get_page(self):
+        if self.page:
+            return self.page
+        try:
+            page = WoWAce.session.get(self.url)
+            if page.status_code in [403, 503]:
+                print('WoWAce (Curse) is blocking requests because it thinks you are a bot... please try later.')
+            page.raise_for_status()  # Raise an exception for HTTP errors
+            self.page = BeautifulSoup(page.text, 'html.parser')
+            return self.page
         except Exception as e:
             raise self.version_error() from e


### PR DESCRIPTION
This adds classic support for WowAce. It also fixes a bug caused by a wrong assumption that the first file in the files list is always a retail version. 

This closes #32 
