### PR TITLE
Move config parsing into own class

### DIFF
--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -14,6 +14,7 @@ from requests import HTTPError
 from updater.site import site_handler, github
 from updater.site.abstract_site import SiteError, AbstractSite
 from updater.site.enum import GameVersion
+from updater.manager.config import Config
 
 
 def error(message: str):
@@ -21,52 +22,26 @@ def error(message: str):
     exit(1)
 
 
-def normalize_path(path: str) -> str:
-    env = platform.platform().lower()
-    if 'linux' in env and 'microsoft' in env:
-        return subprocess.check_output(['wslpath', path], text=True)
-    return path
-
-
 class AddonManager:
     _UNAVAILABLE = 'Unavailable'
 
     def __init__(self, config_file):
         self.manifest = []
-
-        # Read config file
-        if not isfile(config_file):
-            error(f"Failed to read config file. Are you sure there is a file called {config_file}?")
-
-        config = configparser.ConfigParser()
-        config.read(config_file)
-
-        try:
-            self.wow_addon_location = config['WOW ADDON UPDATER']['WoW Addon Location']
-            self.addon_list_file = config['WOW ADDON UPDATER']['Addon List File']
-            self.installed_vers_file = config['WOW ADDON UPDATER']['Installed Versions File']
-            self.game_version = GameVersion[config['WOW ADDON UPDATER']['Game Version']]
-        except Exception:
-            error("Failed to parse configuration file. Are you sure it is formatted correctly?")
-
-        if not isfile(self.addon_list_file):
-            error(f"Failed to read addon list file ({self.addon_list_file}). Are you sure the file exists?")
-
-        self.wow_addon_location = normalize_path(self.wow_addon_location)
-        if not isdir(self.wow_addon_location):
-            error(f"Could not find addon directory ({self.wow_addon_location}). Are you sure it exists?")
+        self.config = Config(config_file)
 
     def update_all(self):
         threads = []
 
-        with open(self.addon_list_file, 'r') as fin:
+        with open(self.config.addon_list_file, 'r') as fin:
             addon_entries = fin.read().splitlines()
 
         # filter any blank lines or lines commented with an octothorp (#)
-        addon_entries = [entry for entry in addon_entries if entry and not entry.startswith('#')]
+        addon_entries = [
+            entry for entry in addon_entries if entry and not entry.startswith('#')]
 
         for addon_entry in addon_entries:
-            thread = threading.Thread(target=self.update_addon, args=(addon_entry,))
+            thread = threading.Thread(
+                target=self.update_addon, args=(addon_entry,))
             threads.append(thread)
         for thread in threads:
             thread.start()
@@ -80,7 +55,7 @@ class AddonManager:
         # Expected format: "mydomain.com/myaddon" or "mydomain.com/myaddon|subfolder"
         addon_url, *subfolder = addon_entry.split('|')
 
-        site = site_handler.get_handler(addon_url, self.game_version)
+        site = site_handler.get_handler(addon_url, self.config.game_version)
 
         addon_name = site.get_addon_name()
 
@@ -100,7 +75,8 @@ class AddonManager:
         elif latest_version == installed_version:
             print(f"{addon_name} version {installed_version} is up to date.\n")
         else:
-            print(f"Installing/updating addon: {addon_name} to version: {latest_version}...\n")
+            print(
+                f"Installing/updating addon: {addon_name} to version: {latest_version}...\n")
 
             try:
                 zip_url = site.find_zip_url()
@@ -110,7 +86,8 @@ class AddonManager:
                 print(f"Failed to download zip for [{addon_name}]")
                 latest_version = AddonManager._UNAVAILABLE
             except KeyError:
-                print(f"Failed to extract subfolder [{subfolder}] in archive for [{addon_name}]")
+                print(
+                    f"Failed to extract subfolder [{subfolder}] in archive for [{addon_name}]")
                 latest_version = AddonManager._UNAVAILABLE
             except SiteError as e:
                 print(e)
@@ -119,7 +96,8 @@ class AddonManager:
                 print(f"Unexpected error unzipping [{addon_name}]")
                 latest_version = AddonManager._UNAVAILABLE
 
-        addon_entry = [addon_name, addon_url, installed_version, latest_version]
+        addon_entry = [addon_name, addon_url,
+                       installed_version, latest_version]
         self.manifest.append(addon_entry)
 
     def get_addon_zip(self, session: requests.Session, zip_url):
@@ -135,11 +113,14 @@ class AddonManager:
             with tempfile.TemporaryDirectory() as temp_dir:
                 # unfortunately include some github-specific folder logic here... think about how to refactor this
                 if '-master' in top_level_folder:
-                    destination_dir = join(self.wow_addon_location, top_level_folder.replace('-master', ''))
+                    destination_dir = join(
+                        self.config.wow_addon_location, top_level_folder.replace('-master', ''))
                     temp_source_dir = join(temp_dir, top_level_folder)
                 if subfolder:
-                    destination_dir = join(self.wow_addon_location, subfolder)
-                    temp_source_dir = join(temp_dir, top_level_folder, subfolder)
+                    destination_dir = join(
+                        self.config.wow_addon_location, subfolder)
+                    temp_source_dir = join(
+                        temp_dir, top_level_folder, subfolder)
                 zipped.extractall(path=temp_dir)
                 if not isdir(temp_source_dir):
                     raise KeyError()
@@ -147,11 +128,11 @@ class AddonManager:
                     shutil.rmtree(destination_dir)
                 shutil.copytree(src=temp_source_dir, dst=destination_dir)
         else:
-            zipped.extractall(path=self.wow_addon_location)
+            zipped.extractall(path=self.config.wow_addon_location)
 
     def get_installed_version(self, addon_name):
         installed_vers = configparser.ConfigParser()
-        installed_vers.read(self.installed_vers_file)
+        installed_vers.read(self.config.installed_vers_file)
         try:
             return installed_vers.get(addon_name, 'version')
         except (configparser.NoSectionError, configparser.NoOptionError):
@@ -161,11 +142,12 @@ class AddonManager:
         versions = {}
         for (addon_name, addon_url, _, new_version) in sorted(self.manifest):
             if new_version != AddonManager._UNAVAILABLE:
-                versions[addon_name] = {"url": addon_url, "version": new_version}
+                versions[addon_name] = {
+                    "url": addon_url, "version": new_version}
 
         installed_versions = configparser.ConfigParser()
         installed_versions.read_dict(versions)
-        with open(self.installed_vers_file, 'wt') as installed_versions_file:
+        with open(self.config.installed_vers_file, 'wt') as installed_versions_file:
             installed_versions.write(installed_versions_file)
 
     def display_results(self):
@@ -176,7 +158,8 @@ class AddonManager:
                   "Up to date" if new == prev else new]
                  for name, _, prev, new in self.manifest]  # eliminate the URL
         results = headers + table
-        col_width = max(len(word) for row in results for word in row) + 2  # padding
+        col_width = max(len(word)
+                        for row in results for word in row) + 2  # padding
         print()
         for row in results:
             print("".join(word.ljust(col_width) for word in row))

--- a/updater/manager/config.py
+++ b/updater/manager/config.py
@@ -1,0 +1,72 @@
+from os.path import isfile, isdir
+import configparser
+import platform
+import subprocess
+
+from updater.site.enum import GameVersion
+
+
+class Config:
+    def __init__(self, config_file):
+        # Read config file
+        if not isfile(config_file):
+            error(
+                f"Failed to read config file. Are you sure there is a file called {config_file}?")
+
+        # Extract config and check if required settings are set
+        try:
+            config = configparser.ConfigParser()
+            config.read(config_file)
+            config = config['WOW ADDON UPDATER']
+
+            self.game_version = self.parse_game_version(config)
+            self.wow_addon_location = self.parse_addon_location(config)
+            self.addon_list_file = config.get('Addon List File', 'addons.txt')
+            self.installed_vers_file = config.get(
+                'Installed Versions File', 'installed.ini')
+            self.self_update = self.parse_self_update(config)
+
+        except Exception:
+            error(
+                'Failed to parse configuration file. Are you sure it is formatted correctly?')
+
+        # Test if addon list exists
+        if not isfile(self.addon_list_file):
+            error(
+                f"Failed to read addon list file ({self.addon_list_file}). Are you sure the file exists?")
+
+    def parse_addon_location(self, config):
+        wow_addon_location = config.get('WoW Addon Location')
+        if wow_addon_location == None:
+            error(
+                'The location of the addon folder is missing from your configuration file.')
+
+        # Normalize path for linux for windows clients
+        wow_addon_location = normalize_path(wow_addon_location)
+
+        if not isdir(wow_addon_location):
+            error(
+                f"Could not find addon directory ({self.wow_addon_location}). Are you sure it exists?")
+        return wow_addon_location
+
+    def parse_game_version(self, config):
+        try:
+            return GameVersion[config['Game Version']]
+        except Exception:
+            error(
+                'The targeted game version is missing from your configuration file or invalid.')
+
+    def parse_self_update(self, config):
+        return str(config.get('Self Update')) in ['yes', 'true', 'y', '1']
+
+
+def normalize_path(path: str) -> str:
+    env = platform.platform().lower()
+    if 'linux' in env and 'microsoft' in env:
+        return subprocess.check_output(['wslpath', path], text=True)
+    return path
+
+
+def error(message: str):
+    print(message)
+    exit(1)


### PR DESCRIPTION
This moves the parsing of the "config.ini" into its own class and allows certain options to be optional. This useful for multiple reasons:

- Reduces complexity of AddonManager
- Allows options to be parse before AddonManager

The reason I propose this change is, because I would like the ability to turn off the self updater (#84), which would mean parsing the options earlier. Rather than moving it to "__main__.py" I feel it would be most appropriate to have it as its own class.