### PR TITLE
Switch from cfscrape to cloudscraper

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,6 @@ coverage = "*"
 [packages]
 requests = "*"
 beautifulsoup4 = "*"
-cfscrape = "*"
+cloudscraper = "*"
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cd1ddff1b0f508f44fe46826948604b63363f22a3d304ee2c606f385ec154e9b"
+            "sha256": "c22970e73afa8f578987c2f6f32828473e7deca80cc94fafd445bb18cb34446f"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,14 +14,54 @@
         ]
     },
     "default": {
+        "asn1crypto": {
+            "hashes": [
+                "sha256:0b199f211ae690df3db4fd6c1c4ff976497fb1da689193e368eedbadc53d9292",
+                "sha256:bca90060bd995c3f62c4433168eab407e44bdbdb567b3f3a396a676c1a4c4a3f"
+            ],
+            "version": "==1.0.1"
+        },
         "beautifulsoup4": {
             "hashes": [
-                "sha256:05668158c7b85b791c5abde53e50265e16f98ad601c402ba44d70f96c4159612",
-                "sha256:25288c9e176f354bf277c0a10aa96c782a6a18a17122dba2e8cec4a97e03343b",
-                "sha256:f040590be10520f2ea4c2ae8c3dae441c7cfff5308ec9d58a0ec0c1b8f81d469"
+                "sha256:5279c36b4b2ec2cb4298d723791467e3000e5384a43ea0cdf5d45207c7e97169",
+                "sha256:6135db2ba678168c07950f9a16c4031822c6f4aec75a65e0a97bc5ca09789931",
+                "sha256:dcdef580e18a76d54002088602eba453eec38ebbcafafeaabd8cab12b6155d57"
             ],
             "index": "pypi",
-            "version": "==4.8.0"
+            "version": "==4.8.1"
+        },
+        "brotli": {
+            "hashes": [
+                "sha256:0538dc1744fd17c314d2adc409ea7d1b779783b89fd95bcfb0c2acc93a6ea5a7",
+                "sha256:0970a47f471782912d7705160b2b0a9306e68e6fadf9cffcaeb42d8f0951e26c",
+                "sha256:113f51658e6fe548dce4b3749f6ef6c24de4184ba9c10a909cbee4261c2a5da0",
+                "sha256:1e1aa9c4d1558889f42749c8baf846007953bfd32c8209230cf1cd1f5ef33495",
+                "sha256:2f2f4f78f29ac4a45d15b3d9fc3fd9705e0ad313a44b129f6e1d0c6916bad0e2",
+                "sha256:3269f6de1dd150fd0cce1c158b61ff5ac06d627fd3ae9c6ea03aed26fbbff7ea",
+                "sha256:50dd9ad2a2bb12da4e9002a438672d182f98e546e99952de80280a1e1729664f",
+                "sha256:5519a4b01b1a4f965083cbfa2ef2b9774c5a5f352341c47b50776ad109423d72",
+                "sha256:5eb27722d320370315971c427eb8aa7cc0791f2a458840d357ac653bd0ad3a14",
+                "sha256:5f06b4d5b6f58e5b5c220c2f23cad034dc5efa51b01fde2351ced1605bd980e2",
+                "sha256:72848d25a5f9e736db4af4512e0c3feecc094d57d241f8f1ae959115a2c39756",
+                "sha256:743001bca75f4a6b4454be3510feca46f9d61a0c782a9bc2bc684bdb245e279e",
+                "sha256:9d1c2dd27a1083fefd05b1b2f8df4a6bc2aaa6c21dd82cd41c8ae5e7c23a87f8",
+                "sha256:a13ce9b419fe9f277c63f700efb0e444331509d1881b5610d2ba7e9080606967",
+                "sha256:a19ef0952b9d2803df88dff07f45a6c92d5676afb9b8d69cf32232d684036d11",
+                "sha256:ad766ca8b8c1419b71a22756b45264f45725c86133dc80a7cbe30b6b78c75620",
+                "sha256:ad7963f261988ee0883816b6b9f206f11461c9b3cb5cfbca0c9ab5adc406d395",
+                "sha256:c16201060c5a3f8742e3deae759014251ac92f382f82bc2a41dc079ff18c3f24",
+                "sha256:c43b202f65891861a9a336984a103de25de235f756de69e32db893156f767013",
+                "sha256:c675c6cce4295cb1a692f3de7416aacace7314e064b94bc86e93aceefce7fd3e",
+                "sha256:d17cec0b992b1434f5f9df9986563605a4d1b1acd5574c87fc2ac014bcbd3316",
+                "sha256:dc91f6129953861a73d9a65c52a8dd682b561a9ebaf65283541645cab6489917",
+                "sha256:e2f4cbd1760d2bf2f30e396c2301999aab0191aec031a6a8a04950b2f575a536",
+                "sha256:f192e6d3556714105c10486bbd6d045e38a0c04d9da3cef21e0a8dfd8e162df4",
+                "sha256:f775b07026af2b1b0b5a8b05e41571cdcf3a315a67df265d60af301656a5425b",
+                "sha256:f969ec7f56ba9636679e69ca07fba548312ccaca37412ee823c7f413541ad7e0",
+                "sha256:f9dc52cd70907aafb99a773b66b156f2f995c7a0d284397c487c8b71ddbef2f9",
+                "sha256:fc7212e36ebeb81aebf7949c92897b622490d7c0e333a479c0395591e7994600"
+            ],
+            "version": "==1.0.7"
         },
         "certifi": {
             "hashes": [
@@ -30,14 +70,38 @@
             ],
             "version": "==2019.9.11"
         },
-        "cfscrape": {
+        "cffi": {
             "hashes": [
-                "sha256:45fb82043f824717345b03bfabd80b19b615eaf3d8228cf1d5c3c50e2c6eb259",
-                "sha256:55913cb9ff2f39ad796fad2ba8888f12707daba4d8a28f3e34957804a4d8ecb8",
-                "sha256:7c52c19b74a10dd29223f03926581754d0f0bf7f94caaeca163e4bb911ca1c4b"
+                "sha256:041c81822e9f84b1d9c401182e174996f0bae9991f33725d059b771744290774",
+                "sha256:046ef9a22f5d3eed06334d01b1e836977eeef500d9b78e9ef693f9380ad0b83d",
+                "sha256:066bc4c7895c91812eff46f4b1c285220947d4aa46fa0a2651ff85f2afae9c90",
+                "sha256:066c7ff148ae33040c01058662d6752fd73fbc8e64787229ea8498c7d7f4041b",
+                "sha256:2444d0c61f03dcd26dbf7600cf64354376ee579acad77aef459e34efcb438c63",
+                "sha256:300832850b8f7967e278870c5d51e3819b9aad8f0a2c8dbe39ab11f119237f45",
+                "sha256:34c77afe85b6b9e967bd8154e3855e847b70ca42043db6ad17f26899a3df1b25",
+                "sha256:46de5fa00f7ac09f020729148ff632819649b3e05a007d286242c4882f7b1dc3",
+                "sha256:4aa8ee7ba27c472d429b980c51e714a24f47ca296d53f4d7868075b175866f4b",
+                "sha256:4d0004eb4351e35ed950c14c11e734182591465a33e960a4ab5e8d4f04d72647",
+                "sha256:4e3d3f31a1e202b0f5a35ba3bc4eb41e2fc2b11c1eff38b362de710bcffb5016",
+                "sha256:50bec6d35e6b1aaeb17f7c4e2b9374ebf95a8975d57863546fa83e8d31bdb8c4",
+                "sha256:55cad9a6df1e2a1d62063f79d0881a414a906a6962bc160ac968cc03ed3efcfb",
+                "sha256:5662ad4e4e84f1eaa8efce5da695c5d2e229c563f9d5ce5b0113f71321bcf753",
+                "sha256:59b4dc008f98fc6ee2bb4fd7fc786a8d70000d058c2bbe2698275bc53a8d3fa7",
+                "sha256:73e1ffefe05e4ccd7bcea61af76f36077b914f92b76f95ccf00b0c1b9186f3f9",
+                "sha256:a1f0fd46eba2d71ce1589f7e50a9e2ffaeb739fb2c11e8192aa2b45d5f6cc41f",
+                "sha256:a2e85dc204556657661051ff4bab75a84e968669765c8a2cd425918699c3d0e8",
+                "sha256:a5457d47dfff24882a21492e5815f891c0ca35fefae8aa742c6c263dac16ef1f",
+                "sha256:a8dccd61d52a8dae4a825cdbb7735da530179fea472903eb871a5513b5abbfdc",
+                "sha256:ae61af521ed676cf16ae94f30fe202781a38d7178b6b4ab622e4eec8cefaff42",
+                "sha256:b012a5edb48288f77a63dba0840c92d0504aa215612da4541b7b42d849bc83a3",
+                "sha256:d2c5cfa536227f57f97c92ac30c8109688ace8fa4ac086d19d0af47d134e2909",
+                "sha256:d42b5796e20aacc9d15e66befb7a345454eef794fdb0737d1af593447c6c8f45",
+                "sha256:dee54f5d30d775f525894d67b1495625dd9322945e7fee00731952e0368ff42d",
+                "sha256:e070535507bd6aa07124258171be2ee8dfc19119c28ca94c9dfb7efd23564512",
+                "sha256:e1ff2748c84d97b065cc95429814cdba39bcbd77c9c85c89344b317dc0d9cbff",
+                "sha256:ed851c75d1e0e043cbf5ca9a8e1b13c4c90f3fbd863dacb01c0808e2b5204201"
             ],
-            "index": "pypi",
-            "version": "==2.0.8"
+            "version": "==1.12.3"
         },
         "chardet": {
             "hashes": [
@@ -46,12 +110,75 @@
             ],
             "version": "==3.0.4"
         },
+        "cloudscraper": {
+            "hashes": [
+                "sha256:2316ddc0c00905536a3f1801917e68fb78610776b1b65f1b126627a7793c397b",
+                "sha256:a27d2452edbe3d77d089c71f74783edfd24802e4f100aef0fad0de4505a2b840"
+            ],
+            "index": "pypi",
+            "version": "==1.2.2"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:24b61e5fcb506424d3ec4e18bca995833839bf13c59fc43e530e488f28d46b8c",
+                "sha256:25dd1581a183e9e7a806fe0543f485103232f940fcfc301db65e630512cce643",
+                "sha256:3452bba7c21c69f2df772762be0066c7ed5dc65df494a1d53a58b683a83e1216",
+                "sha256:41a0be220dd1ed9e998f5891948306eb8c812b512dc398e5a01846d855050799",
+                "sha256:5751d8a11b956fbfa314f6553d186b94aa70fdb03d8a4d4f1c82dcacf0cbe28a",
+                "sha256:5f61c7d749048fa6e3322258b4263463bfccefecb0dd731b6561cb617a1d9bb9",
+                "sha256:72e24c521fa2106f19623a3851e9f89ddfdeb9ac63871c7643790f872a305dfc",
+                "sha256:7b97ae6ef5cba2e3bb14256625423413d5ce8d1abb91d4f29b6d1a081da765f8",
+                "sha256:961e886d8a3590fd2c723cf07be14e2a91cf53c25f02435c04d39e90780e3b53",
+                "sha256:96d8473848e984184b6728e2c9d391482008646276c3ff084a1bd89e15ff53a1",
+                "sha256:ae536da50c7ad1e002c3eee101871d93abdc90d9c5f651818450a0d3af718609",
+                "sha256:b0db0cecf396033abb4a93c95d1602f268b3a68bb0a9cc06a7cff587bb9a7292",
+                "sha256:cfee9164954c186b191b91d4193989ca994703b2fff406f71cf454a2d3c7327e",
+                "sha256:e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6",
+                "sha256:f27d93f0139a3c056172ebb5d4f9056e770fdf0206c2f422ff2ebbad142e09ed",
+                "sha256:f57b76e46a58b63d1c6375017f4564a28f19a5ca912691fd2e4261b3414b618d"
+            ],
+            "version": "==2.7"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
             "version": "==2.8"
+        },
+        "js2py": {
+            "hashes": [
+                "sha256:6e5628abfff2fb4051e8e77a353e44831f474e2ceb865278271897f7f326aeb6",
+                "sha256:bf87cb4432944470f11fed9c1cb8d0312dd505e7b867362f55102f24379ab94f"
+            ],
+            "version": "==0.66"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+            ],
+            "version": "==2.19"
+        },
+        "pyjsparser": {
+            "hashes": [
+                "sha256:2b12842df98d83f65934e0772fa4a5d8b123b3bc79f1af1789172ac70265dd21",
+                "sha256:be60da6b778cc5a5296a69d8e7d614f1f870faf94e1b1b6ac591f2ad5d729579"
+            ],
+            "version": "==2.7.1"
+        },
+        "pyopenssl": {
+            "hashes": [
+                "sha256:aeca66338f6de19d1aa46ed634c3b9ae519a64b458f8468aec688e7e3c20f200",
+                "sha256:c727930ad54b10fc157015014b666f2d8b41f70c0d03e83ab67624fd3dd5d1e6"
+            ],
+            "version": "==19.0.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+            ],
+            "version": "==2019.3"
         },
         "requests": {
             "hashes": [
@@ -61,12 +188,33 @@
             "index": "pypi",
             "version": "==2.22.0"
         },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
+                "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
+            ],
+            "version": "==0.9.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
         "soupsieve": {
             "hashes": [
                 "sha256:605f89ad5fdbfefe30cdc293303665eff2d188865d4dbe4eb510bba1edfbfce3",
                 "sha256:b91d676b330a0ebd5b21719cb6e9b57c57d433671f65b9c28dd3461d9a1ed0b6"
             ],
             "version": "==1.9.4"
+        },
+        "tzlocal": {
+            "hashes": [
+                "sha256:11c9f16e0a633b4b60e1eede97d8a46340d042e67b670b290ca526576e039048",
+                "sha256:949b9dd5ba4be17190a80c0268167d7e6c92c62b30026cf9764caf3e308e5590"
+            ],
+            "version": "==2.0.0"
         },
         "urllib3": {
             "hashes": [

--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -14,6 +14,7 @@ from requests import HTTPError
 from updater.site import site_handler, github
 from updater.site.abstract_site import SiteError, AbstractSite
 from updater.site.enum import GameVersion
+from updater.manager.config import Config
 
 
 def error(message: str):
@@ -21,52 +22,26 @@ def error(message: str):
     exit(1)
 
 
-def normalize_path(path: str) -> str:
-    env = platform.platform().lower()
-    if 'linux' in env and 'microsoft' in env:
-        return subprocess.check_output(['wslpath', path], text=True)
-    return path
-
-
 class AddonManager:
     _UNAVAILABLE = 'Unavailable'
 
     def __init__(self, config_file):
         self.manifest = []
-
-        # Read config file
-        if not isfile(config_file):
-            error(f"Failed to read config file. Are you sure there is a file called {config_file}?")
-
-        config = configparser.ConfigParser()
-        config.read(config_file)
-
-        try:
-            self.wow_addon_location = config['WOW ADDON UPDATER']['WoW Addon Location']
-            self.addon_list_file = config['WOW ADDON UPDATER']['Addon List File']
-            self.installed_vers_file = config['WOW ADDON UPDATER']['Installed Versions File']
-            self.game_version = GameVersion[config['WOW ADDON UPDATER']['Game Version']]
-        except Exception:
-            error("Failed to parse configuration file. Are you sure it is formatted correctly?")
-
-        if not isfile(self.addon_list_file):
-            error(f"Failed to read addon list file ({self.addon_list_file}). Are you sure the file exists?")
-
-        self.wow_addon_location = normalize_path(self.wow_addon_location)
-        if not isdir(self.wow_addon_location):
-            error(f"Could not find addon directory ({self.wow_addon_location}). Are you sure it exists?")
+        self.config = Config(config_file)
 
     def update_all(self):
         threads = []
 
-        with open(self.addon_list_file, 'r') as fin:
+        with open(self.config.addon_list_file, 'r') as fin:
             addon_entries = fin.read().splitlines()
 
         # filter any blank lines or lines commented with an octothorp (#)
-        addon_entries = [entry for entry in addon_entries if entry and not entry.startswith('#')]
+        addon_entries = [
+            entry for entry in addon_entries if entry and not entry.startswith('#')]
 
         for addon_entry in addon_entries:
-            thread = threading.Thread(target=self.update_addon, args=(addon_entry,))
+            thread = threading.Thread(
+                target=self.update_addon, args=(addon_entry,))
             threads.append(thread)
         for thread in threads:
             thread.start()
@@ -80,7 +55,7 @@ class AddonManager:
         # Expected format: "mydomain.com/myaddon" or "mydomain.com/myaddon|subfolder"
         addon_url, *subfolder = addon_entry.split('|')
 
-        site = site_handler.get_handler(addon_url, self.game_version)
+        site = site_handler.get_handler(addon_url, self.config.game_version)
 
         addon_name = site.get_addon_name()
 
@@ -100,7 +75,8 @@ class AddonManager:
         elif latest_version == installed_version:
             print(f"{addon_name} version {installed_version} is up to date.\n")
         else:
-            print(f"Installing/updating addon: {addon_name} to version: {latest_version}...\n")
+            print(
+                f"Installing/updating addon: {addon_name} to version: {latest_version}...\n")
 
             try:
                 zip_url = site.find_zip_url()
@@ -110,7 +86,8 @@ class AddonManager:
                 print(f"Failed to download zip for [{addon_name}]")
                 latest_version = AddonManager._UNAVAILABLE
             except KeyError:
-                print(f"Failed to extract subfolder [{subfolder}] in archive for [{addon_name}]")
+                print(
+                    f"Failed to extract subfolder [{subfolder}] in archive for [{addon_name}]")
                 latest_version = AddonManager._UNAVAILABLE
             except SiteError as e:
                 print(e)
@@ -119,7 +96,8 @@ class AddonManager:
                 print(f"Unexpected error unzipping [{addon_name}]")
                 latest_version = AddonManager._UNAVAILABLE
 
-        addon_entry = [addon_name, addon_url, installed_version, latest_version]
+        addon_entry = [addon_name, addon_url,
+                       installed_version, latest_version]
         self.manifest.append(addon_entry)
 
     def get_addon_zip(self, session: requests.Session, zip_url):
@@ -135,11 +113,14 @@ class AddonManager:
             with tempfile.TemporaryDirectory() as temp_dir:
                 # unfortunately include some github-specific folder logic here... think about how to refactor this
                 if '-master' in top_level_folder:
-                    destination_dir = join(self.wow_addon_location, top_level_folder.replace('-master', ''))
+                    destination_dir = join(
+                        self.config.wow_addon_location, top_level_folder.replace('-master', ''))
                     temp_source_dir = join(temp_dir, top_level_folder)
                 if subfolder:
-                    destination_dir = join(self.wow_addon_location, subfolder)
-                    temp_source_dir = join(temp_dir, top_level_folder, subfolder)
+                    destination_dir = join(
+                        self.config.wow_addon_location, subfolder)
+                    temp_source_dir = join(
+                        temp_dir, top_level_folder, subfolder)
                 zipped.extractall(path=temp_dir)
                 if not isdir(temp_source_dir):
                     raise KeyError()
@@ -147,11 +128,11 @@ class AddonManager:
                     shutil.rmtree(destination_dir)
                 shutil.copytree(src=temp_source_dir, dst=destination_dir)
         else:
-            zipped.extractall(path=self.wow_addon_location)
+            zipped.extractall(path=self.config.wow_addon_location)
 
     def get_installed_version(self, addon_name):
         installed_vers = configparser.ConfigParser()
-        installed_vers.read(self.installed_vers_file)
+        installed_vers.read(self.config.installed_vers_file)
         try:
             return installed_vers.get(addon_name, 'version')
         except (configparser.NoSectionError, configparser.NoOptionError):
@@ -161,11 +142,12 @@ class AddonManager:
         versions = {}
         for (addon_name, addon_url, _, new_version) in sorted(self.manifest):
             if new_version != AddonManager._UNAVAILABLE:
-                versions[addon_name] = {"url": addon_url, "version": new_version}
+                versions[addon_name] = {
+                    "url": addon_url, "version": new_version}
 
         installed_versions = configparser.ConfigParser()
         installed_versions.read_dict(versions)
-        with open(self.installed_vers_file, 'wt') as installed_versions_file:
+        with open(self.config.installed_vers_file, 'wt') as installed_versions_file:
             installed_versions.write(installed_versions_file)
 
     def display_results(self):
@@ -176,7 +158,8 @@ class AddonManager:
                   "Up to date" if new == prev else new]
                  for name, _, prev, new in self.manifest]  # eliminate the URL
         results = headers + table
-        col_width = max(len(word) for row in results for word in row) + 2  # padding
+        col_width = max(len(word)
+                        for row in results for word in row) + 2  # padding
         print()
         for row in results:
             print("".join(word.ljust(col_width) for word in row))

--- a/updater/manager/config.py
+++ b/updater/manager/config.py
@@ -1,0 +1,72 @@
+from os.path import isfile, isdir
+import configparser
+import platform
+import subprocess
+
+from updater.site.enum import GameVersion
+
+
+class Config:
+    def __init__(self, config_file):
+        # Read config file
+        if not isfile(config_file):
+            error(
+                f"Failed to read config file. Are you sure there is a file called {config_file}?")
+
+        # Extract config and check if required settings are set
+        try:
+            config = configparser.ConfigParser()
+            config.read(config_file)
+            config = config['WOW ADDON UPDATER']
+
+            self.game_version = self.parse_game_version(config)
+            self.wow_addon_location = self.parse_addon_location(config)
+            self.addon_list_file = config.get('Addon List File', 'addons.txt')
+            self.installed_vers_file = config.get(
+                'Installed Versions File', 'installed.ini')
+            self.self_update = self.parse_self_update(config)
+
+        except Exception:
+            error(
+                'Failed to parse configuration file. Are you sure it is formatted correctly?')
+
+        # Test if addon list exists
+        if not isfile(self.addon_list_file):
+            error(
+                f"Failed to read addon list file ({self.addon_list_file}). Are you sure the file exists?")
+
+    def parse_addon_location(self, config):
+        wow_addon_location = config.get('WoW Addon Location')
+        if wow_addon_location == None:
+            error(
+                'The location of the addon folder is missing from your configuration file.')
+
+        # Normalize path for linux for windows clients
+        wow_addon_location = normalize_path(wow_addon_location)
+
+        if not isdir(wow_addon_location):
+            error(
+                f"Could not find addon directory ({self.wow_addon_location}). Are you sure it exists?")
+        return wow_addon_location
+
+    def parse_game_version(self, config):
+        try:
+            return GameVersion[config['Game Version']]
+        except Exception:
+            error(
+                'The targeted game version is missing from your configuration file or invalid.')
+
+    def parse_self_update(self, config):
+        return str(config.get('Self Update')) in ['yes', 'true', 'y', '1']
+
+
+def normalize_path(path: str) -> str:
+    env = platform.platform().lower()
+    if 'linux' in env and 'microsoft' in env:
+        return subprocess.check_output(['wslpath', path], text=True)
+    return path
+
+
+def error(message: str):
+    print(message)
+    exit(1)

--- a/updater/site/abstract_site.py
+++ b/updater/site/abstract_site.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 
 import requests
+import cloudscraper
+import subprocess
 
 from updater.site.enum import GameVersion
 
@@ -29,6 +31,19 @@ class AbstractSite(ABC):
             raise NotImplementedError(f"Can't instantiate class {cls.__name__}"
                                       " without list of supported URLs cls._URLS")
         return cls._URLS
+
+    @classmethod
+    def get_scraper(cls):
+        try:
+            subprocess.check_output(["node", "-v"])
+            node_supported = True
+        except Exception:
+            node_supported = False
+
+        if node_supported:
+            return cloudscraper.create_scraper()
+        else:
+            return cloudscraper.create_scraper(interpreter="nodejs")
 
     @abstractmethod
     def find_zip_url(self) -> str:

--- a/updater/site/curse.py
+++ b/updater/site/curse.py
@@ -1,7 +1,5 @@
 import re
 
-import cfscrape
-
 from updater.site.abstract_site import AbstractSite, SiteError
 from updater.site.enum import GameVersion
 
@@ -17,7 +15,7 @@ class Curse(AbstractSite):
         _OLD_PROJECT_URL
     ]
 
-    session = cfscrape.create_scraper("https://www.curseforge.com/")
+    session = AbstractSite.get_scraper()
 
     def __init__(self, url: str, game_version: GameVersion):
         url = Curse._convert_old_curse_urls(url)
@@ -41,7 +39,8 @@ class Curse(AbstractSite):
         try:
             page = Curse.session.get(self.url)
             if page.status_code in [403, 503]:
-                print("Curse is blocking requests because it thinks you are a bot... please try later.")
+                print(
+                    "Curse is blocking requests because it thinks you are a bot... please try later.")
             page.raise_for_status()  # Raise an exception for HTTP errors
             content_string = str(page.content)
             # the first one encountered will be the WoW retail version
@@ -63,6 +62,7 @@ class Curse(AbstractSite):
                 page.raise_for_status()
                 return page.url
             except Exception as e:
-                raise SiteError(f"Failed to find the current page for old URL: {url}") from e
+                raise SiteError(
+                    f"Failed to find the current page for old URL: {url}") from e
         else:
             return url

--- a/updater/site/wowace.py
+++ b/updater/site/wowace.py
@@ -1,4 +1,3 @@
-import cfscrape
 from bs4 import BeautifulSoup
 
 from updater.site.abstract_site import AbstractSite
@@ -11,7 +10,7 @@ class WoWAce(AbstractSite):
         'https://wowace.com/projects/'
     ]
 
-    session = cfscrape.create_scraper()
+    session = AbstractSite.get_scraper()
 
     def __init__(self, url: str, game_version: GameVersion):
         super().__init__(url, game_version)


### PR DESCRIPTION
This switches to [cloudscraper](https://github.com/VeNoMouS/cloudscraper) for cloudflare circumvention. This has the benefit of making nodejs an optional dependency, by default [js2py](https://github.com/PiotrDabkowski/Js2Py) is used, which works just as well in my testing.

I don't know the reasons you choose cfscrape over cloudscraper, but it might be something to consider changing.