### PR TITLE
Fix/90/GitHub intermittent failures

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 Changelog
 
+* 10/11/2019 - v1.4.2
+Use a new internal method of fetching GitHub addons which appears to be more reliable, and fails less often.
+
 * 10/11/2019 - v1.4.1
 Fix for an issue involving subfolders and archives that aren't from git (GitHub, ElvUI). For example, you can now correctly extract single subfolders from Curse, etc.
 


### PR DESCRIPTION
Fixes #90 

Switch `site/github.py` to both pull HTML from the commits page (https://github.../commits/master) and to use BeautifulSoup instead of raw regex parsing. This appears to make it more reliable, since the existing method had a pretty high failure rate. It was seen failing in Travis tests frequently, and locally as well.