### PR TITLE
Update TukUI Download Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,16 @@ https://www.curseforge.com/wow/addons/deadly-boss-mods
 https://www.curseforge.com/wow/addons/auctionator
 https://www.wowinterface.com/downloads/info24005-RavenousMounts.html
 https://www.github.com/some-user/some-addon-repo
+https://www.tukui.org/classic-addons.php?id=2
 ```
 
 Each link needs to be the main page for the addon, as shown above.
 
 ### Addons archives containing subfolders
-If you want to extract a subfolder from the default downloaded folder (typically needed with Tukui addons), add a pipe character (`|`) and the name of the subfolder at the end of the line. For example, the ElvUI addon can be added as follows:
+If you want to extract a subfolder from the default downloaded folder, add a pipe character (`|`) and the name of the subfolder at the end of the line. For example, the ElvUI addon can be added as follows:
 
 ```
-https://git.tukui.org/elvui/elvui|ElvUI
+https://www.github.com/some-user/some-addon-repo|AddOn
 ```
 
 ## Contributing

--- a/test/site/test_tukui.py
+++ b/test/site/test_tukui.py
@@ -5,20 +5,19 @@ from updater.site import tukui
 
 class TestTukui(unittest.TestCase):
     def setUp(self):
-        self.url = 'https://git.tukui.org/elvui/elvui'
+        self.url = 'https://www.tukui.org/classic-addons.php?id=2'
         self.tukui = tukui.Tukui(self.url)
 
     def test_integration_tukui_find_zip_url(self):
         zip_url = self.tukui.find_zip_url()
-        self.assertRegex(zip_url, rf"{self.url}/-/archive/v[0-9]+\.[0-9]+/elvui-v[0-9]+\.[0-9]+\.zip")
-
+        self.assertEqual(zip_url, 'https://www.tukui.org/classic-addons.php?download=2')
     def test_integration_tukui_get_addon_name(self):
         addon_name = self.tukui.get_addon_name()
-        self.assertEqual(addon_name, 'elvui')
+        self.assertEqual(addon_name, 'ElvUI')
 
     def test_integration_tukui_get_latest_version(self):
         latest_version = self.tukui.get_latest_version()
-        self.assertRegex(latest_version, r"(v[0-9]+\.[0-9]+)")  # something like v12.34
+        self.assertRegex(latest_version, r"([0-9]+\.[0-9]+)")  # something like v12.34
 
     def test_tukui_get_supported_urls(self):
         supported_urls = self.tukui.get_supported_urls()

--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -130,7 +130,7 @@ class AddonManager:
             norm_src_dir = temp_dir
             destination_dir = self.wow_addon_location
 
-            if isinstance(site, github.GitHub) or isinstance(site, tukui.Tukui):
+            if isinstance(site, github.GitHub):
                 first_zip_member, *_ = zipped.namelist()
                 # sometimes zips don't contain an entry for the top-level folder, so parse it from the first member
                 top_level_folder, *_ = first_zip_member.split('/')

--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -142,7 +142,7 @@ class AddonManager:
                 destination_dir = join(self.wow_addon_location, subfolder)
                 norm_src_dir = join(norm_src_dir, subfolder)
 
-            if subfolder or isinstance(site, github.GitHub) or isinstance(site, tukui.Tukui):
+            if subfolder or isinstance(site, github.GitHub):
                 zipped.extractall(path=temp_dir)
                 if not isdir(norm_src_dir):
                     raise KeyError()

--- a/updater/site/tukui.py
+++ b/updater/site/tukui.py
@@ -19,15 +19,10 @@ class Tukui(AbstractSite):
 
     def find_zip_url(self):
         version = self.get_latest_version()
-        # like https://git.tukui.org/elvui/elvui/-/archive/v11.21/elvui-v11.21.zip
-        #return f"{self.url}/-/archive/{version}/{self.get_addon_name()}-{version}.zip"
         
+        # like https://www.tukui.org/classic-addons.php?download=2
         downloadpage = self.url.replace('id', 'download')
-        return downloadpage
-        #try:
-        #   response = Tukui.session.get(downloadpage)
-        #   response.raise_for_status()
-            
+        return downloadpage          
 
     def get_latest_version(self):
         if self.latest_version:

--- a/updater/site/tukui.py
+++ b/updater/site/tukui.py
@@ -7,7 +7,7 @@ from updater.site.enum import GameVersion
 
 class Tukui(AbstractSite):
     _URLS = [
-        'https://git.tukui.org/elvui/'
+        'https://www.tukui.org/'
     ]
 
     session = requests.session()
@@ -20,17 +20,32 @@ class Tukui(AbstractSite):
     def find_zip_url(self):
         version = self.get_latest_version()
         # like https://git.tukui.org/elvui/elvui/-/archive/v11.21/elvui-v11.21.zip
-        return f"{self.url}/-/archive/{version}/{self.get_addon_name()}-{version}.zip"
+        #return f"{self.url}/-/archive/{version}/{self.get_addon_name()}-{version}.zip"
+        
+        downloadpage = self.url.replace('id', 'download')
+        return downloadpage
+        #try:
+        #   response = Tukui.session.get(downloadpage)
+        #   response.raise_for_status()
+            
 
     def get_latest_version(self):
         if self.latest_version:
             return self.latest_version
         try:
-            response = Tukui.session.get(self.url + '/-/tags')
+            response = Tukui.session.get(self.url + '#extras')
             response.raise_for_status()
-            tags_page = BeautifulSoup(response.text, 'html.parser')
-            version = tags_page.find('div', {'class': 'tags'}).find('a').string
+            content_string = str(response.content)
+            index_of_ver = content_string.find('The latest version of this addon is <b class="VIP">') + 51
+            end_tag = content_string.find('</b>')
+            return content_string[index_of_ver:end_tag].strip()
         except Exception as e:
             raise self.version_error() from e
-        self.latest_version = version
-        return self.latest_version
+
+    def get_addon_name(self):
+        response = Tukui.session.get(self.url)
+        response.raise_for_status()
+        page = BeautifulSoup(response.text, 'html.parser')
+        name = page.find('span', attrs={'class': 'Member'})
+        addon_name = name.text.strip()
+        return addon_name


### PR DESCRIPTION
Updated the structure for TukUI to match that of their main website. This refactor now allows for the download and installation of any addon (both classic and retail) by using the TukUI main website, rather than the repo (not all projects seem to be publically listed on there).

Updated the test cases and removed specialised coding for the unzipping of the addon, as the main website does not have subfolders any more.

Updated documentation to include sample TukUI links and to remove mention of subfolder formatting for TukUI.

Tested with ElvUI, ElvUI Nuts and Bolts and AddOnSkins. Test cases also came back positive.

I'm not much of a programmer, so there may be some inefficiencies in my code.

Fixes #111 

