### PR TITLE
Implemented wait to exit in Python

### DIFF
--- a/run_MacLinux.sh
+++ b/run_MacLinux.sh
@@ -1,2 +1,1 @@
 pipenv run python -m updater
-read -n1 -r -p "Press anything to close..."

--- a/run_Windows.bat
+++ b/run_Windows.bat
@@ -1,3 +1,2 @@
 @echo off
 pipenv run python -m updater
-PAUSE

--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -183,3 +183,4 @@ class AddonManager:
         col_width = max(len(word) for row in results for word in row) + 2  # padding
         results = ["".join(word.ljust(col_width) for word in row) for row in results]
         logger.info('\n'.join(results))
+        input("Press Enter to continue...")


### PR DESCRIPTION
I implemented pressing enter to exit instead of any key through the launch scripts. This allows easier launching under Linux where the window will quickly exit unless you open in Terminal this is already open.