### PR TITLE
Fix support for retail tukui/elvui addons via their download pages

### DIFF
--- a/test/site/test_tukui.py
+++ b/test/site/test_tukui.py
@@ -1,29 +1,42 @@
 import unittest
 
-from updater.site import tukui
+from updater.site.tukui import Tukui
+
+version_test_data = [
+    ['https://www.tukui.org/classic-addons.php?id=1', 'https://www.tukui.org/classic-addons.php?download=1', 'Tukui'],
+    ['https://www.tukui.org/classic-addons.php?id=2', 'https://www.tukui.org/classic-addons.php?download=2', 'ElvUI'],
+    ['https://www.tukui.org/download.php?ui=tukui', 'https://www.tukui.org/downloads/tukui-', 'Tukui'],
+    ['https://www.tukui.org/download.php?ui=elvui', 'https://www.tukui.org/downloads/elvui-', 'ElvUI'],
+    ['https://www.tukui.org/addons.php?id=3', 'https://www.tukui.org/addons.php?download=3', 'AddOnSkins']
+]
 
 
 class TestTukui(unittest.TestCase):
-    def setUp(self):
-        self.url = 'https://www.tukui.org/classic-addons.php?id=2'
-        self.tukui = tukui.Tukui(self.url)
+    def data(self):
+        for url, exp_dl_url, exp_name in version_test_data:
+            with self.subTest((url, exp_dl_url, exp_name)):
+                yield Tukui(url), exp_dl_url, exp_name
 
     def test_integration_tukui_find_zip_url(self):
-        zip_url = self.tukui.find_zip_url()
-        self.assertEqual(zip_url, 'https://www.tukui.org/classic-addons.php?download=2')
+        for client, exp_dl_url, exp_name in self.data():
+            zip_url = client.find_zip_url()
+            self.assertTrue(exp_dl_url in zip_url)
 
     def test_integration_tukui_get_addon_name(self):
-        addon_name = self.tukui.get_addon_name()
-        self.assertEqual(addon_name, 'ElvUI')
+        for client, exp_dl_url, exp_name in self.data():
+            addon_name = client.get_addon_name()
+            self.assertEqual(addon_name, exp_name)
 
     def test_integration_tukui_get_latest_version(self):
-        latest_version = self.tukui.get_latest_version()
-        self.assertRegex(latest_version, r"([0-9]+\.[0-9]+)")  # something like v12.34
+        for client, exp_dl_url, exp_name in self.data():
+            latest_version = client.get_latest_version()
+            self.assertRegex(latest_version, r'([0-9]+\.[0-9]+)')  # something like v12.34
 
     def test_tukui_get_supported_urls(self):
-        supported_urls = self.tukui.get_supported_urls()
-        self.assertIsNotNone(supported_urls)
-        self.assertTrue(len(supported_urls) != 0)
+        for client, exp_dl_url, exp_name in self.data():
+            supported_urls = client.get_supported_urls()
+            self.assertIsNotNone(supported_urls)
+            self.assertTrue(len(supported_urls) != 0)
 
 
 if __name__ == '__main__':

--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -83,7 +83,10 @@ class AddonManager:
 
         site = site_handler.get_handler(addon_url, self.game_version)
 
-        addon_name = site.get_addon_name()
+        try:
+            addon_name = site.get_addon_name()
+        except Exception as e:
+            logger.exception(e)
 
         if subfolder:
             [subfolder] = subfolder

--- a/updater/site/tukui.py
+++ b/updater/site/tukui.py
@@ -1,3 +1,5 @@
+import re
+
 import requests
 from bs4 import BeautifulSoup
 
@@ -14,33 +16,66 @@ class Tukui(AbstractSite):
 
     latest_version = None
 
+    _page: BeautifulSoup = None
+
+    _version_pattern = r'(?P<version>[\d]+\.[\d]+)'
+
     def __init__(self, url: str):
         super().__init__(url, GameVersion.agnostic)
 
     def find_zip_url(self):
-        version = self.get_latest_version()
-        
-        # like https://www.tukui.org/classic-addons.php?download=2
-        downloadpage = self.url.replace('id', 'download')
-        return downloadpage          
+        # For classic or retail misc addons:
+        # https://www.tukui.org/classic-addons.php?id=1
+        # or https://www.tukui.org/addons.php?id=3
+        # becomes
+        # https://www.tukui.org/classic-addons.php?download=1
+        # and https://www.tukui.org/addons.php?id=3
+        #
+        # Or for retail ONLY elvui and tukui themselves:
+        # https://www.tukui.org/download.php?ui=tukui
+        # https://www.tukui.org/download.php?ui=elvui
+        # becomes
+        # https://www.tukui.org/downloads/elvui-11.372.zip
+
+        if self._is_special_tukui_link():
+            download_link = self._get_page().find('a', attrs={'class': 'btn'})['href']
+            download_link = Tukui._URLS[0] + download_link[1:]  # take off the leading / from the href
+        else:
+            download_link = self.url.replace('id', 'download')
+        return download_link
 
     def get_latest_version(self):
-        if self.latest_version:
-            return self.latest_version
         try:
-            response = Tukui.session.get(self.url + '#extras')
-            response.raise_for_status()
-            content_string = str(response.content)
-            index_of_ver = content_string.find('The latest version of this addon is <b class="VIP">') + 51
-            end_tag = content_string.find('</b>')
-            return content_string[index_of_ver:end_tag].strip()
+            if self._is_special_tukui_link():
+                version = re.search(self._version_pattern, self.find_zip_url()).group(1)
+            else:
+                response = Tukui.session.get(self.url + '#extras')
+                response.raise_for_status()
+                text = response.text
+                version = re.search(f'>{self._version_pattern}<', text).group(1)
+            self.latest_version = version
+            return version
         except Exception as e:
             raise self.version_error() from e
 
     def get_addon_name(self):
-        response = Tukui.session.get(self.url)
-        response.raise_for_status()
-        page = BeautifulSoup(response.text, 'html.parser')
-        name = page.find('span', attrs={'class': 'Member'})
-        addon_name = name.text.strip()
+        if self._is_special_tukui_link():
+            # wow I hate this so much, but it works
+            return "ElvUI" if self.url.endswith("elvui") else "Tukui"
+        else:
+            name = self._get_page().find('span', attrs={'class': 'Member'})
+            addon_name = name.text.strip()
         return addon_name
+
+    def _is_special_tukui_link(self):
+        return any([self.url.endswith(ending) for ending in ['tukui', 'elvui']])
+
+    def _get_page(self):
+        try:
+            if not self._page:
+                response = Tukui.session.get(self.url)
+                response.raise_for_status()
+                self._page = BeautifulSoup(response.text, 'html.parser')
+            return self._page
+        except Exception as e:
+            raise self.download_error() from e


### PR DESCRIPTION
Test cases:

#### 1
urls:

https://www.tukui.org/classic-addons.php?id=1
https://www.tukui.org/classic-addons.php?id=2

results in

```
> pipenv run python -m updater -c .\config-test.ini
Installing/updating addon: Tukui to version: 1.36...

Installing/updating addon: ElvUI to version: 1.24...



Name           Prev. Version  New Version
────           ─────────────  ───────────
Tukui          -----          1.36
ElvUI          -----          1.24
```

in folder:

![image](https://user-images.githubusercontent.com/5453928/80436905-39a55b00-88ce-11ea-9ed7-05f685a789e8.png)

#### 2

urls:
https://www.tukui.org/addons.php?id=3
https://www.tukui.org/download.php?ui=tukui
https://www.tukui.org/download.php?ui=elvui

results in:

```
> pipenv run python -m updater -c .\config-test.ini
Installing/updating addon: Tukui to version: 18.28...

Installing/updating addon: ElvUI to version: 11.372...

Installing/updating addon: AddOnSkins to version: 4.40...



Name           Prev. Version  New Version
────           ─────────────  ───────────
Tukui          -----          18.28
AddOnSkins     -----          4.40
ElvUI          -----          11.372
```

in folder:

![image](https://user-images.githubusercontent.com/5453928/80437020-8852f500-88ce-11ea-82f2-a6ba7e935b2f.png)
