### PR TITLE
Add gitattributes for to fix linguist language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/resources/* linguist-vendored


### PR DESCRIPTION
Excludes all the content in the `test/resources` directory from GitHub's language stats. 

This should fix the issue of the project showing up as HTML. Addresses #155 

Apparently it can take some time for the repo to reflect this update, but in the fork it seems to be working.