### PR TITLE
remove newline of wslpath output

### DIFF
--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -28,7 +28,7 @@ def error(message: str):
 def normalize_path(path: str) -> str:
     env = platform.platform().lower()
     if 'linux' in env and 'microsoft' in env:
-        return subprocess.check_output(['wslpath', path], text=True)
+        return subprocess.check_output(['wslpath', path], text=True).strip()
     return path
 
 


### PR DESCRIPTION
Under WSL, the normalize_path function uses the output of the command "wslpath" to transform the Windows path into the WSL path. This, however, adds a newline to the path which makes "isdir" fail:
```
$ pipenv run python -m updater
Could not find addon directory (/mnt/c/Games/World of Warcraft/_retail_/Interface/AddOns
). Are you sure it exists?
Something bad happened. Please check the logs.
```

This PR adds ".strip()" to the output of "wslpath" in order to remove the newline. With this change, the script runs successfully:
```
$ pipenv run python -m updater
Installing/updating addon: BugSack to version: 249206c...



Name           Prev. Version  New Version
────           ─────────────  ───────────
BugSack        -----          249206c
```