### PR TITLE
Support github releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
--
+- Added support for addons in the form of GitHub releases, separately from GitHub commits
 
 ## v1.9.2 - 08/03/2021
 - Fix bug where an entry in `installed.ini` could be zeroed out if there was an error updating the addon

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ It requires that some properties be set, if you do not want to use the defaults 
 - `Game Version`
     - The game version (`retail`, `classic` or `tbc`) that you would like to target for addons 
     - (default `= retail`)
+
+## The `GitHub` Section
+
+To support a higher API request limit, you can add your own [personal GitHub access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to the configuration.
+The tool will use the token when making requests to GitHub, reducing the chance of you being rate-limited.
+
+To use, uncomment the section in the `config.ini`, and populate the `token` with a value.
     
 ## Multiple configurations
 The module supports a command-line configuration for maintaining multiple set of addons. For example, a set of addons for retail, and a different set of addons for classic.

--- a/config.ini
+++ b/config.ini
@@ -4,3 +4,8 @@ Addon List File = addons.txt
 Installed Versions File = installed.ini
 # retail,classic or tbc
 Game Version = retail
+
+# Optional personal access token for github
+#[GitHub]
+#username = username_here
+#token = token_here

--- a/config.ini
+++ b/config.ini
@@ -7,5 +7,4 @@ Game Version = retail
 
 # Optional personal access token for github
 #[GitHub]
-#username = username_here
 #token = token_here

--- a/test/manager/test_addon_manager.py
+++ b/test/manager/test_addon_manager.py
@@ -42,6 +42,7 @@ class TestAddonManager(unittest.TestCase):
         self.manager.manifest = []
         self.manager.get_installed_version = Mock(return_value=EXP_INST_VERSION)
         self.manager.game_version = GameVersion.retail
+        self.manager.site_credentials = {}
 
         self.addCleanup(patcher.stop)
 

--- a/test/site/test_github_release.py
+++ b/test/site/test_github_release.py
@@ -1,0 +1,38 @@
+import unittest
+import os
+
+from updater.site.github_release import GitHubRelease
+
+
+class TestGithubRelease(unittest.TestCase):
+    def setUp(self):
+        self.url = "https://github.com/smp4903/FiveSecondRule/releases"
+        credentials = None
+        if token := os.environ.get("GITHUB_TOKEN"):
+            credentials = {"token": token}
+        self.github = GitHubRelease(self.url, credentials)
+
+    def test_integration_github_find_zip_url(self):
+        zip_url = self.github.find_zip_url()
+        self.assertRegex(
+            zip_url,
+            r"^https://github\.com/smp4903/FiveSecondRule/releases/download/.+\.zip$",
+        )
+
+    def test_integration_github_get_addon_name(self):
+        addon_name = self.github.get_addon_name()
+        self.assertEqual(addon_name, "FiveSecondRule")
+
+    def test_integration_github_get_latest_version(self):
+        latest_version = self.github.get_latest_version()
+        self.assertIsInstance(latest_version, str)
+        self.assertNotEqual(latest_version, "")
+
+    def test_github_get_supported_urls(self):
+        supported_urls = self.github.get_supported_urls()
+        self.assertIsNotNone(supported_urls)
+        self.assertTrue(len(supported_urls) != 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/site/test_site_handler.py
+++ b/test/site/test_site_handler.py
@@ -4,16 +4,20 @@ from unittest.mock import MagicMock, patch
 from updater.site import site_handler
 from updater.site.curse import Curse
 from updater.site.enum import AddonVersion, GameVersion
+from updater.site.github import GitHub
+from updater.site.github_release import GitHubRelease
 from updater.site.tukui import Tukui
 from updater.site.wowace import WoWAce
 from updater.site.wowinterface import WoWInterface
 
 
+
 class TestSiteHandler(unittest.TestCase):
+
     @patch.object(Curse, '_normalize_curse_urls', MagicMock(return_value=''))
     def test_handles_curse(self):
         for url in Curse.get_supported_urls():
-            handler = site_handler.get_handler(url, GameVersion.retail)
+            handler = site_handler.get_handler(url, GameVersion.retail, {})
             self.assertIsInstance(handler, Curse)
 
     @patch.object(Curse, '_normalize_curse_urls', MagicMock(return_value=''))
@@ -21,23 +25,37 @@ class TestSiteHandler(unittest.TestCase):
         addon_versions = AddonVersion.__members__.values()
         for url in Curse.get_supported_urls():
             for version in addon_versions:
-                handler = site_handler.get_handler(url, GameVersion.retail, version)
+                handler = site_handler.get_handler(url, GameVersion.retail, {}, version)
                 self.assertEqual(handler.addon_version, version)
 
     def test_handles_wowace(self):
         for url in WoWAce.get_supported_urls():
-            handler = site_handler.get_handler(url, GameVersion.retail)
+            handler = site_handler.get_handler(url, GameVersion.retail, {})
             self.assertIsInstance(handler, WoWAce)
 
     def test_handles_tukui(self):
         for url in WoWInterface.get_supported_urls():
-            handler = site_handler.get_handler(url, GameVersion.retail)
+            handler = site_handler.get_handler(url, GameVersion.retail, {})
             self.assertIsInstance(handler, WoWInterface)
 
     def test_handles_wowinterface(self):
         for url in Tukui.get_supported_urls():
-            handler = site_handler.get_handler(url, GameVersion.retail)
+            handler = site_handler.get_handler(url, GameVersion.retail, {})
             self.assertIsInstance(handler, Tukui)
+    
+    def test_handles_github(self):
+        for url in GitHub.get_supported_urls():
+            handler = site_handler.get_handler(
+                f"{url}owner/repo", GameVersion.retail, {}
+            )
+            self.assertIsInstance(handler, GitHub)
+    
+    def test_handles_github_release(self):
+        for url in GitHubRelease.get_supported_urls():
+            handler = site_handler.get_handler(
+                f"{url}owner/repo/releases", GameVersion.retail, {}
+            )
+            self.assertIsInstance(handler, GitHubRelease)
 
 
 if __name__ == '__main__':

--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -53,7 +53,6 @@ class AddonManager:
             self.game_version = GameVersion[config['WOW ADDON UPDATER']['Game Version']]
             if "GitHub" in config:
                 self.site_credentials["GitHub"] = {
-                    "username": config["GitHub"]["username"],
                     "token": config["GitHub"]["token"],
                 }
         except Exception:

--- a/updater/manager/addon_manager.py
+++ b/updater/manager/addon_manager.py
@@ -44,12 +44,18 @@ class AddonManager:
 
         config = configparser.ConfigParser()
         config.read(config_file)
+        self.site_credentials = {}
 
         try:
             self.wow_addon_location = config['WOW ADDON UPDATER']['WoW Addon Location']
             self.addon_list_file = config['WOW ADDON UPDATER']['Addon List File']
             self.installed_vers_file = config['WOW ADDON UPDATER']['Installed Versions File']
             self.game_version = GameVersion[config['WOW ADDON UPDATER']['Game Version']]
+            if "GitHub" in config:
+                self.site_credentials["GitHub"] = {
+                    "username": config["GitHub"]["username"],
+                    "token": config["GitHub"]["token"],
+                }
         except Exception:
             error("Failed to parse configuration file. Are you sure it is formatted correctly?")
 
@@ -85,7 +91,9 @@ class AddonManager:
 
         addon_version_track = self.validate_addon_version_track(addon_version_track)
 
-        site = site_handler.get_handler(addon_url, self.game_version, addon_version_track)
+        site = site_handler.get_handler(
+            addon_url, self.game_version, self.site_credentials, addon_version_track
+        )
 
         try:
             addon_name = site.get_addon_name()

--- a/updater/site/github.py
+++ b/updater/site/github.py
@@ -1,5 +1,6 @@
 import requests
 from bs4 import BeautifulSoup
+import re
 
 from updater.site.abstract_site import AbstractSite
 from updater.site.enum import GameVersion
@@ -15,6 +16,10 @@ class GitHub(AbstractSite):
 
     def __init__(self, url: str):
         super().__init__(url, GameVersion.agnostic)
+
+    @classmethod
+    def handles(cls, url: str) -> bool:
+        return bool(re.match('^https://(www.)?github.com/[^/]+/[^/]+/?$', url))
 
     def find_zip_url(self):
         return self.url + '/archive/master.zip'

--- a/updater/site/github.py
+++ b/updater/site/github.py
@@ -19,7 +19,7 @@ class GitHub(AbstractSite):
 
     @classmethod
     def handles(cls, url: str) -> bool:
-        return bool(re.match('^https://(www.)?github.com/[^/]+/[^/]+/?$', url))
+        return bool(re.match('^https://(www\.)?github\.com/[^/]+/[^/]+/?$', url))
 
     def find_zip_url(self):
         return self.url + '/archive/master.zip'

--- a/updater/site/github_release.py
+++ b/updater/site/github_release.py
@@ -2,7 +2,7 @@ import requests
 import re
 from bs4 import BeautifulSoup
 
-from typing import Optional
+from typing import Dict, Optional
 from updater.site.abstract_site import AbstractSite
 from updater.site.github import GitHub
 from updater.site.enum import GameVersion
@@ -13,7 +13,7 @@ class GitHubRelease(AbstractSite):
 
     session = requests.session()
 
-    def __init__(self, url: str, credentials: Optional[dict[str, str]]):
+    def __init__(self, url: str, credentials: Optional[Dict[str, str]]):
         self.headers = {}
         if credentials and (token := credentials.get("token")):
             self.headers["authorization"] = f"token {token}"

--- a/updater/site/github_release.py
+++ b/updater/site/github_release.py
@@ -43,7 +43,7 @@ class GitHubRelease(AbstractSite):
         raise self.download_error()
 
     def _get_repo_name(self):
-        _, owner, repo, _ = self.url.removeprefix('https://').split('/', 4)
+        _, owner, repo, _ = self.url.replace('https://', "", 1).split('/', 4)
         return f'{owner}/{repo}'
 
     def get_latest_version(self):

--- a/updater/site/github_release.py
+++ b/updater/site/github_release.py
@@ -21,7 +21,7 @@ class GitHubRelease(AbstractSite):
 
     @classmethod
     def handles(cls, url: str) -> bool:
-        return bool(re.match('^https://(www.)?github.com/[^/]+/[^/]+/releases/?$', url))
+        return bool(re.match('^https://(www\.)?github\.com/[^/]+/[^/]+/releases/?$', url))
 
     def find_zip_url(self):
         try:

--- a/updater/site/github_release.py
+++ b/updater/site/github_release.py
@@ -1,0 +1,61 @@
+import requests
+import re
+from bs4 import BeautifulSoup
+
+from updater.site.abstract_site import AbstractSite
+from updater.site.github import GitHub
+from updater.site.enum import GameVersion
+
+
+class GitHubRelease(AbstractSite):
+    _URLS = ['https://www.github.com/', 'https://github.com/']
+
+    session = requests.session()
+
+    def __init__(self, url: str):
+        super().__init__(url, GameVersion.agnostic)
+
+    @classmethod
+    def handles(cls, url: str) -> bool:
+        v = bool(re.match('^https://(www.)?github.com/[^/]+/[^/]+/releases/?$', url))
+        return bool(re.match('^https://(www.)?github.com/[^/]+/[^/]+/releases/?$', url))
+
+    def find_zip_url(self):
+        try:
+            repo = self._get_repo_name()
+            response = GitHubRelease.session.get(
+                f'https://api.github.com/repos/{repo}/releases'
+            )
+            response.raise_for_status()
+            data = response.json()
+            # First zip file asset in a non-prerelease
+            for entry in data:
+                if not entry['draft'] and not entry['prerelease']:
+                    for asset in entry['assets']:
+                        if asset['content_type'] == 'application/zip':
+                            return asset['browser_download_url']
+        except Exception as e:
+            raise self.download_error() from e
+        raise self.download_error()
+
+    def _get_repo_name(self):
+        _, owner, repo, _ = self.url.removeprefix('https://').split('/', 4)
+        return f'{owner}/{repo}'
+
+    def get_latest_version(self):
+        try:
+            repo = self._get_repo_name()
+            response = GitHubRelease.session.get(
+                f'https://api.github.com/repos/{repo}/releases'
+            )
+            response.raise_for_status()
+            data = response.json()
+            for entry in data:
+                if not entry['draft'] and not entry['prerelease']:
+                    return entry['tag_name']
+            raise RuntimeError('Humm no valid version found')
+        except Exception as e:
+            raise self.version_error() from e
+
+    def get_addon_name(self):
+        return self._get_repo_name().split('/')[-1]

--- a/updater/site/site_handler.py
+++ b/updater/site/site_handler.py
@@ -13,6 +13,7 @@ class UnknownSiteError(RuntimeError):
 
 
 def get_handler(url: str, game_version: GameVersion,
+                site_credentials: dict[str, dict[str, str]],
                 addon_version: AddonVersion = AddonVersion.release) -> AbstractSite:
     if Curse.handles(url):
         return Curse(url, game_version, addon_version)
@@ -25,7 +26,7 @@ def get_handler(url: str, game_version: GameVersion,
     elif GitHub.handles(url):
         return GitHub(url)
     elif GitHubRelease.handles(url):
-        return GitHubRelease(url)
+        return GitHubRelease(url, site_credentials.get("GitHub"))
 
     # for subclass in Site.__subclasses__():
     #     if subclass.handles(url):

--- a/updater/site/site_handler.py
+++ b/updater/site/site_handler.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from updater.site.abstract_site import AbstractSite
 from updater.site.curse import Curse
 from updater.site.enum import AddonVersion, GameVersion
@@ -13,7 +14,7 @@ class UnknownSiteError(RuntimeError):
 
 
 def get_handler(url: str, game_version: GameVersion,
-                site_credentials: dict[str, dict[str, str]],
+                site_credentials: Dict[str, Dict[str, str]],
                 addon_version: AddonVersion = AddonVersion.release) -> AbstractSite:
     if Curse.handles(url):
         return Curse(url, game_version, addon_version)

--- a/updater/site/site_handler.py
+++ b/updater/site/site_handler.py
@@ -2,6 +2,7 @@ from updater.site.abstract_site import AbstractSite
 from updater.site.curse import Curse
 from updater.site.enum import AddonVersion, GameVersion
 from updater.site.github import GitHub
+from updater.site.github_release import GitHubRelease
 from updater.site.tukui import Tukui
 from updater.site.wowace import WoWAce
 from updater.site.wowinterface import WoWInterface
@@ -23,6 +24,8 @@ def get_handler(url: str, game_version: GameVersion,
         return WoWInterface(url, game_version)
     elif GitHub.handles(url):
         return GitHub(url)
+    elif GitHubRelease.handles(url):
+        return GitHubRelease(url)
 
     # for subclass in Site.__subclasses__():
     #     if subclass.handles(url):


### PR DESCRIPTION
As mentioned in #199, this pull request adds an extra site handler `GitHubReleases` which handles using github releases as source for addons. The way it recognizes that a release should be used instead of the default branch is by detecting github urls that end in /releases. For example:

```
https://github.com/WeakAuras/WeakAuras2/releases
https://github.com/BigWigsMods/BigWigs/releases
```

I opted for this because that seemed to be the only reasonable way to distinguish between different github sources. Appending extra data after the URL seems to already be in use and would require more changes. This url scheme can also be easily extended to `/tags` (some addon repos create tags but not releases).

I opted for creating a second class for two reasons:

 * The GitHub class already receives special treatment for unzipping the files (in the addon manager code).
 * The logic for finding the release zips and versions is nicely separated

It has one downside though: the `GitHubReleases` has its own session and thus uses a separate cookiejar. I don't think this is a significant issue but I'm open to change this if you have suggestions. Both the `GitHub` and `GitHubReleases` class now override the `AbstractSite.handles` method instead of using the default implementation, I'm open to changing that if you have suggestions there too.


Edit: I just edited my addons.txt and went over all addons, converting them to use the author's github releases when available. Roughly half my addons.txt now uses github releases.